### PR TITLE
Add requirements.txt to allow git clone && pip install -r requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pynput==1.6.8
+pyperclip==1.7.0


### PR DESCRIPTION
This makes it easier to set this up for testing / debugging (instead of pip install, we can install the requirements and modify it as necessary.)