### PR TITLE
Convert character to upper if shift in special_keys.

### DIFF
--- a/keyboard_listener.py
+++ b/keyboard_listener.py
@@ -45,6 +45,8 @@ class KeyboardListener:
 
 class Combo:
     def __init__(self, special_keys, character, function, *args, **kwargs):
+        if 'shift' in special_keys:
+            character = character.upper()
         self.special_keys = special_keys
         self.character = character
         self.function = function

--- a/keyboard_listener.py
+++ b/keyboard_listener.py
@@ -47,6 +47,8 @@ class Combo:
     def __init__(self, special_keys, character, function, *args, **kwargs):
         if 'shift' in special_keys:
             character = character.upper()
+        elif character.is_upper():
+            special_keys = ['shift'] + special_keys
         self.special_keys = special_keys
         self.character = character
         self.function = function


### PR DESCRIPTION
The Combo class should not depend on the user capitalizing their character correctly, since the code will silently fail without warning the user. Additionally, if the character is uppercase, then the combination is a shift combination, and should be modified to reflect that.